### PR TITLE
Route all android system audio to app

### DIFF
--- a/A2dpSinkActivity.java
+++ b/A2dpSinkActivity.java
@@ -1,0 +1,322 @@
+package com.example.bluetootha2dpsink;
+
+import android.Manifest;
+import android.app.Activity;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.ListView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A2DP Sink演示Activity
+ * 展示如何使用BluetoothA2dpSink API
+ */
+public class A2dpSinkActivity extends Activity {
+    private static final String TAG = "A2dpSinkActivity";
+    private static final int REQUEST_BLUETOOTH_PERMISSIONS = 1;
+    
+    private BluetoothA2dpSinkDemo mA2dpSinkDemo;
+    private BluetoothAdapter mBluetoothAdapter;
+    
+    private TextView mStatusText;
+    private ListView mDevicesList;
+    private Button mEnableButton;
+    private Button mScanButton;
+    private Button mDisconnectButton;
+    
+    private ArrayAdapter<String> mDevicesAdapter;
+    private List<BluetoothDevice> mPairedDevices = new ArrayList<>();
+    
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        
+        // 初始化UI（这里使用代码创建，实际项目中应使用XML布局）
+        initializeUI();
+        
+        // 检查并请求权限
+        checkPermissions();
+        
+        // 初始化蓝牙
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (mBluetoothAdapter == null) {
+            showMessage("设备不支持蓝牙");
+            finish();
+            return;
+        }
+        
+        // 初始化A2DP Sink
+        mA2dpSinkDemo = new BluetoothA2dpSinkDemo(this);
+    }
+    
+    /**
+     * 检查和请求必要的权限
+     */
+    private void checkPermissions() {
+        List<String> permissions = new ArrayList<>();
+        
+        // 蓝牙基础权限
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH) 
+                != PackageManager.PERMISSION_GRANTED) {
+            permissions.add(Manifest.permission.BLUETOOTH);
+        }
+        
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_ADMIN) 
+                != PackageManager.PERMISSION_GRANTED) {
+            permissions.add(Manifest.permission.BLUETOOTH_ADMIN);
+        }
+        
+        // Android 6.0+需要位置权限来扫描蓝牙设备
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) 
+                    != PackageManager.PERMISSION_GRANTED) {
+                permissions.add(Manifest.permission.ACCESS_FINE_LOCATION);
+            }
+        }
+        
+        // Android 12+需要新的蓝牙权限
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_CONNECT) 
+                    != PackageManager.PERMISSION_GRANTED) {
+                permissions.add(Manifest.permission.BLUETOOTH_CONNECT);
+            }
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.BLUETOOTH_SCAN) 
+                    != PackageManager.PERMISSION_GRANTED) {
+                permissions.add(Manifest.permission.BLUETOOTH_SCAN);
+            }
+        }
+        
+        if (!permissions.isEmpty()) {
+            ActivityCompat.requestPermissions(this, 
+                permissions.toArray(new String[0]), REQUEST_BLUETOOTH_PERMISSIONS);
+        }
+    }
+    
+    /**
+     * 初始化UI（简化版，实际应使用XML布局）
+     */
+    private void initializeUI() {
+        // 这里应该使用setContentView(R.layout.activity_a2dp_sink)
+        // 以下代码仅作演示
+        
+        mStatusText = new TextView(this);
+        mStatusText.setText("A2DP Sink状态：未初始化");
+        
+        mEnableButton = new Button(this);
+        mEnableButton.setText("启用A2DP Sink");
+        mEnableButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                enableA2dpSink();
+            }
+        });
+        
+        mScanButton = new Button(this);
+        mScanButton.setText("扫描已配对设备");
+        mScanButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                scanPairedDevices();
+            }
+        });
+        
+        mDisconnectButton = new Button(this);
+        mDisconnectButton.setText("断开所有连接");
+        mDisconnectButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                disconnectAll();
+            }
+        });
+        
+        mDevicesList = new ListView(this);
+        mDevicesAdapter = new ArrayAdapter<>(this, android.R.layout.simple_list_item_1);
+        mDevicesList.setAdapter(mDevicesAdapter);
+        
+        // 设置设备列表点击事件
+        mDevicesList.setOnItemClickListener((parent, view, position, id) -> {
+            if (position < mPairedDevices.size()) {
+                BluetoothDevice device = mPairedDevices.get(position);
+                connectToDevice(device);
+            }
+        });
+    }
+    
+    /**
+     * 启用A2DP Sink
+     */
+    private void enableA2dpSink() {
+        if (!mBluetoothAdapter.isEnabled()) {
+            showMessage("请先开启蓝牙");
+            // 请求开启蓝牙
+            mBluetoothAdapter.enable();
+            return;
+        }
+        
+        mA2dpSinkDemo.initializeA2dpSink();
+        updateStatus("A2DP Sink已启用，等待连接...");
+        
+        // 延迟扫描已配对设备
+        mDevicesList.postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                scanPairedDevices();
+            }
+        }, 1000);
+    }
+    
+    /**
+     * 扫描已配对的设备
+     */
+    private void scanPairedDevices() {
+        if (!mBluetoothAdapter.isEnabled()) {
+            showMessage("蓝牙未开启");
+            return;
+        }
+        
+        mPairedDevices.clear();
+        mDevicesAdapter.clear();
+        
+        // 获取已配对设备
+        Set<BluetoothDevice> pairedDevices = mBluetoothAdapter.getBondedDevices();
+        if (pairedDevices != null && !pairedDevices.isEmpty()) {
+            for (BluetoothDevice device : pairedDevices) {
+                mPairedDevices.add(device);
+                String deviceInfo = device.getName() + "\n" + device.getAddress();
+                
+                // 检查设备是否支持A2DP
+                if (isA2dpDevice(device)) {
+                    deviceInfo += " (A2DP)";
+                }
+                
+                mDevicesAdapter.add(deviceInfo);
+            }
+            updateStatus("找到 " + pairedDevices.size() + " 个已配对设备");
+        } else {
+            updateStatus("没有找到已配对设备");
+        }
+        
+        // 获取当前连接的设备
+        List<BluetoothDevice> connectedDevices = mA2dpSinkDemo.getConnectedDevices();
+        if (connectedDevices != null && !connectedDevices.isEmpty()) {
+            updateStatus("已连接 " + connectedDevices.size() + " 个设备");
+        }
+    }
+    
+    /**
+     * 检查设备是否支持A2DP
+     */
+    private boolean isA2dpDevice(BluetoothDevice device) {
+        if (device == null) return false;
+        
+        // 获取设备类型
+        int deviceClass = device.getBluetoothClass().getDeviceClass();
+        
+        // 检查是否是音频设备
+        return (deviceClass == 0x240404 ||  // Headphones
+                deviceClass == 0x240408 ||  // Headset
+                deviceClass == 0x240418 ||  // Loudspeaker
+                deviceClass == 0x240414);   // Car Audio
+    }
+    
+    /**
+     * 连接到指定设备
+     */
+    private void connectToDevice(BluetoothDevice device) {
+        if (device == null) return;
+        
+        updateStatus("正在连接到 " + device.getName() + "...");
+        
+        boolean success = mA2dpSinkDemo.connectToDevice(device);
+        if (success) {
+            updateStatus("连接请求已发送");
+        } else {
+            updateStatus("连接失败");
+        }
+    }
+    
+    /**
+     * 断开所有连接
+     */
+    private void disconnectAll() {
+        List<BluetoothDevice> connectedDevices = mA2dpSinkDemo.getConnectedDevices();
+        if (connectedDevices != null && !connectedDevices.isEmpty()) {
+            for (BluetoothDevice device : connectedDevices) {
+                mA2dpSinkDemo.disconnectDevice(device);
+            }
+            updateStatus("已断开所有连接");
+        } else {
+            updateStatus("没有活动连接");
+        }
+    }
+    
+    /**
+     * 更新状态显示
+     */
+    private void updateStatus(final String status) {
+        runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if (mStatusText != null) {
+                    mStatusText.setText("状态：" + status);
+                }
+                Log.d(TAG, status);
+            }
+        });
+    }
+    
+    /**
+     * 显示消息
+     */
+    private void showMessage(String message) {
+        Toast.makeText(this, message, Toast.LENGTH_SHORT).show();
+        Log.d(TAG, message);
+    }
+    
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String[] permissions, int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+        
+        if (requestCode == REQUEST_BLUETOOTH_PERMISSIONS) {
+            boolean allGranted = true;
+            for (int result : grantResults) {
+                if (result != PackageManager.PERMISSION_GRANTED) {
+                    allGranted = false;
+                    break;
+                }
+            }
+            
+            if (allGranted) {
+                showMessage("权限已授予");
+                enableA2dpSink();
+            } else {
+                showMessage("需要蓝牙权限才能使用此功能");
+            }
+        }
+    }
+    
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        
+        // 清理资源
+        if (mA2dpSinkDemo != null) {
+            mA2dpSinkDemo.cleanup();
+        }
+    }
+}

--- a/A2dpSinkAudioHandler.java
+++ b/A2dpSinkAudioHandler.java
@@ -1,0 +1,330 @@
+package com.example.bluetootha2dpsink;
+
+import android.media.AudioAttributes;
+import android.media.AudioFormat;
+import android.media.AudioManager;
+import android.media.AudioRecord;
+import android.media.AudioTrack;
+import android.media.MediaCodec;
+import android.media.MediaCodecInfo;
+import android.media.MediaFormat;
+import android.os.Build;
+import android.util.Log;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A2DP Sink音频处理器
+ * 处理接收到的蓝牙音频流
+ */
+public class A2dpSinkAudioHandler {
+    private static final String TAG = "A2dpSinkAudioHandler";
+    
+    // 音频参数
+    private static final int SAMPLE_RATE = 44100; // 44.1kHz
+    private static final int CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_STEREO;
+    private static final int AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT;
+    
+    // SBC编解码器参数
+    private static final String SBC_MIME_TYPE = "audio/sbc";
+    private static final int SBC_SAMPLE_RATE = 44100;
+    private static final int SBC_CHANNEL_COUNT = 2;
+    private static final int SBC_BIT_RATE = 328000; // 328 kbps
+    
+    private AudioTrack mAudioTrack;
+    private MediaCodec mDecoder;
+    private boolean mIsPlaying = false;
+    private Thread mPlaybackThread;
+    
+    // 音频缓冲区
+    private static final int BUFFER_SIZE_FACTOR = 4;
+    private byte[] mAudioBuffer;
+    private int mBufferSize;
+    
+    public A2dpSinkAudioHandler() {
+        initializeAudioTrack();
+    }
+    
+    /**
+     * 初始化AudioTrack用于播放音频
+     */
+    private void initializeAudioTrack() {
+        // 计算缓冲区大小
+        mBufferSize = AudioTrack.getMinBufferSize(
+            SAMPLE_RATE, 
+            AudioFormat.CHANNEL_OUT_STEREO,
+            AUDIO_FORMAT
+        ) * BUFFER_SIZE_FACTOR;
+        
+        mAudioBuffer = new byte[mBufferSize];
+        
+        // 创建AudioTrack
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build();
+            
+            AudioFormat format = new AudioFormat.Builder()
+                .setSampleRate(SAMPLE_RATE)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                .setEncoding(AUDIO_FORMAT)
+                .build();
+            
+            mAudioTrack = new AudioTrack.Builder()
+                .setAudioAttributes(attributes)
+                .setAudioFormat(format)
+                .setBufferSizeInBytes(mBufferSize)
+                .setTransferMode(AudioTrack.MODE_STREAM)
+                .build();
+        } else {
+            mAudioTrack = new AudioTrack(
+                AudioManager.STREAM_MUSIC,
+                SAMPLE_RATE,
+                AudioFormat.CHANNEL_OUT_STEREO,
+                AUDIO_FORMAT,
+                mBufferSize,
+                AudioTrack.MODE_STREAM
+            );
+        }
+        
+        Log.d(TAG, "AudioTrack initialized with buffer size: " + mBufferSize);
+    }
+    
+    /**
+     * 初始化SBC解码器
+     */
+    private void initializeSbcDecoder() {
+        try {
+            // 创建SBC解码器
+            mDecoder = MediaCodec.createDecoderByType(SBC_MIME_TYPE);
+            
+            // 配置解码器
+            MediaFormat format = MediaFormat.createAudioFormat(
+                SBC_MIME_TYPE,
+                SBC_SAMPLE_RATE,
+                SBC_CHANNEL_COUNT
+            );
+            format.setInteger(MediaFormat.KEY_BIT_RATE, SBC_BIT_RATE);
+            format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 1024);
+            
+            mDecoder.configure(format, null, null, 0);
+            mDecoder.start();
+            
+            Log.d(TAG, "SBC decoder initialized");
+            
+        } catch (IOException e) {
+            Log.e(TAG, "Failed to initialize SBC decoder", e);
+            // 如果SBC解码器不可用，回退到PCM
+            mDecoder = null;
+        }
+    }
+    
+    /**
+     * 开始音频播放
+     */
+    public void startPlayback() {
+        if (mIsPlaying) {
+            Log.w(TAG, "Already playing");
+            return;
+        }
+        
+        mIsPlaying = true;
+        
+        if (mAudioTrack != null) {
+            mAudioTrack.play();
+        }
+        
+        // 启动播放线程
+        mPlaybackThread = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                playbackLoop();
+            }
+        });
+        mPlaybackThread.start();
+        
+        Log.d(TAG, "Playback started");
+    }
+    
+    /**
+     * 停止音频播放
+     */
+    public void stopPlayback() {
+        mIsPlaying = false;
+        
+        if (mPlaybackThread != null) {
+            try {
+                mPlaybackThread.join(1000);
+            } catch (InterruptedException e) {
+                Log.e(TAG, "Playback thread interrupted", e);
+            }
+            mPlaybackThread = null;
+        }
+        
+        if (mAudioTrack != null) {
+            mAudioTrack.stop();
+            mAudioTrack.flush();
+        }
+        
+        Log.d(TAG, "Playback stopped");
+    }
+    
+    /**
+     * 播放循环
+     */
+    private void playbackLoop() {
+        android.os.Process.setThreadPriority(android.os.Process.THREAD_PRIORITY_AUDIO);
+        
+        while (mIsPlaying) {
+            // 这里应该从蓝牙音频流中读取数据
+            // 实际实现需要与BluetoothA2dpSink的音频数据回调集成
+            
+            // 模拟音频数据处理
+            processAudioData();
+            
+            try {
+                Thread.sleep(10); // 简单的延迟，实际应该基于音频缓冲区状态
+            } catch (InterruptedException e) {
+                break;
+            }
+        }
+    }
+    
+    /**
+     * 处理音频数据
+     * 这个方法应该被蓝牙音频数据接收回调调用
+     */
+    public void processAudioData(byte[] audioData, int offset, int length) {
+        if (!mIsPlaying || mAudioTrack == null) {
+            return;
+        }
+        
+        // 如果是SBC编码的数据，先解码
+        if (mDecoder != null && isSbcData(audioData, offset)) {
+            byte[] pcmData = decodeSbc(audioData, offset, length);
+            if (pcmData != null) {
+                writeAudioData(pcmData, 0, pcmData.length);
+            }
+        } else {
+            // 直接写入PCM数据
+            writeAudioData(audioData, offset, length);
+        }
+    }
+    
+    /**
+     * 模拟音频数据处理（用于测试）
+     */
+    private void processAudioData() {
+        // 生成测试音频数据（静音）
+        byte[] testData = new byte[1024];
+        writeAudioData(testData, 0, testData.length);
+    }
+    
+    /**
+     * 写入音频数据到AudioTrack
+     */
+    private void writeAudioData(byte[] data, int offset, int length) {
+        if (mAudioTrack != null && mAudioTrack.getState() == AudioTrack.STATE_INITIALIZED) {
+            int written = mAudioTrack.write(data, offset, length);
+            if (written < 0) {
+                Log.e(TAG, "AudioTrack write error: " + written);
+            }
+        }
+    }
+    
+    /**
+     * 检查是否是SBC编码的数据
+     */
+    private boolean isSbcData(byte[] data, int offset) {
+        // SBC帧头检测（简化版）
+        // 实际的SBC帧头为0x9C或其他值，取决于配置
+        if (data.length > offset && (data[offset] & 0xFF) == 0x9C) {
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * 解码SBC数据
+     */
+    private byte[] decodeSbc(byte[] sbcData, int offset, int length) {
+        if (mDecoder == null) {
+            return null;
+        }
+        
+        try {
+            // 获取输入缓冲区
+            int inputBufferIndex = mDecoder.dequeueInputBuffer(0);
+            if (inputBufferIndex >= 0) {
+                ByteBuffer inputBuffer = mDecoder.getInputBuffer(inputBufferIndex);
+                inputBuffer.clear();
+                inputBuffer.put(sbcData, offset, length);
+                
+                mDecoder.queueInputBuffer(inputBufferIndex, 0, length, 0, 0);
+            }
+            
+            // 获取输出缓冲区
+            MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+            int outputBufferIndex = mDecoder.dequeueOutputBuffer(info, 0);
+            
+            if (outputBufferIndex >= 0) {
+                ByteBuffer outputBuffer = mDecoder.getOutputBuffer(outputBufferIndex);
+                byte[] pcmData = new byte[info.size];
+                outputBuffer.get(pcmData);
+                
+                mDecoder.releaseOutputBuffer(outputBufferIndex, false);
+                return pcmData;
+            }
+            
+        } catch (Exception e) {
+            Log.e(TAG, "SBC decode error", e);
+        }
+        
+        return null;
+    }
+    
+    /**
+     * 设置音量
+     */
+    public void setVolume(float volume) {
+        if (mAudioTrack != null) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                mAudioTrack.setVolume(volume);
+            } else {
+                mAudioTrack.setStereoVolume(volume, volume);
+            }
+        }
+    }
+    
+    /**
+     * 获取当前播放位置（毫秒）
+     */
+    public long getPlaybackPosition() {
+        if (mAudioTrack != null) {
+            return (mAudioTrack.getPlaybackHeadPosition() * 1000L) / SAMPLE_RATE;
+        }
+        return 0;
+    }
+    
+    /**
+     * 释放资源
+     */
+    public void release() {
+        stopPlayback();
+        
+        if (mAudioTrack != null) {
+            mAudioTrack.release();
+            mAudioTrack = null;
+        }
+        
+        if (mDecoder != null) {
+            mDecoder.stop();
+            mDecoder.release();
+            mDecoder = null;
+        }
+        
+        Log.d(TAG, "Audio handler released");
+    }
+}

--- a/AndroidManifest_permissions.xml
+++ b/AndroidManifest_permissions.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- 在AndroidManifest.xml中需要添加的权限和配置 -->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.bluetootha2dpsink">
+    
+    <!-- 蓝牙基础权限 -->
+    <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    
+    <!-- Android 6.0+ 扫描蓝牙设备需要位置权限 -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    
+    <!-- Android 12+ 新的蓝牙权限 -->
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    
+    <!-- 音频相关权限 -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    
+    <!-- 前台服务权限（如果需要保持连接） -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    
+    <!-- 系统级权限（需要系统签名或Root） -->
+    <!-- 以下权限通常需要系统应用才能获得 -->
+    <uses-permission android:name="android.permission.BLUETOOTH_PRIVILEGED" />
+    <uses-permission android:name="android.permission.INTERACT_ACROSS_USERS_FULL" />
+    
+    <!-- 声明应用需要蓝牙功能 -->
+    <uses-feature android:name="android.hardware.bluetooth" android:required="true" />
+    <uses-feature android:name="android.hardware.bluetooth_le" android:required="false" />
+    
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:theme="@style/AppTheme">
+        
+        <!-- 主Activity -->
+        <activity android:name=".A2dpSinkActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        
+        <!-- 可选：声明为系统应用（需要系统签名） -->
+        <!-- android:sharedUserId="android.uid.system" -->
+        
+    </application>
+    
+</manifest>

--- a/BluetoothA2dpSinkDemo.java
+++ b/BluetoothA2dpSinkDemo.java
@@ -1,0 +1,439 @@
+package com.example.bluetootha2dpsink;
+
+import android.bluetooth.BluetoothA2dp;
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothProfile;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioAttributes;
+import android.media.AudioFocusRequest;
+import android.media.AudioManager;
+import android.os.Build;
+import android.util.Log;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * BluetoothA2dpSink 实现示例
+ * 注意：BluetoothA2dpSink 是隐藏API，需要通过反射访问
+ * 需要系统签名或Root权限才能正常工作
+ */
+public class BluetoothA2dpSinkDemo {
+    private static final String TAG = "A2dpSinkDemo";
+    
+    // BluetoothA2dpSink的类名（隐藏API）
+    private static final String A2DP_SINK_CLASS = "android.bluetooth.BluetoothA2dpSink";
+    
+    // A2DP Sink Profile ID (值为11)
+    private static final int A2DP_SINK_PROFILE = 11;
+    
+    private Context mContext;
+    private BluetoothAdapter mBluetoothAdapter;
+    private Object mA2dpSinkProxy; // BluetoothA2dpSink实例
+    private AudioManager mAudioManager;
+    private AudioFocusRequest mFocusRequest;
+    
+    // 反射相关的Method对象
+    private Method mConnectMethod;
+    private Method mDisconnectMethod;
+    private Method mGetConnectionStateMethod;
+    private Method mGetConnectedDevicesMethod;
+    private Method mSetPriorityMethod;
+    
+    public BluetoothA2dpSinkDemo(Context context) {
+        mContext = context;
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        mAudioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    }
+    
+    /**
+     * 初始化A2DP Sink服务
+     */
+    public void initializeA2dpSink() {
+        if (mBluetoothAdapter == null) {
+            Log.e(TAG, "Bluetooth not supported");
+            return;
+        }
+        
+        if (!mBluetoothAdapter.isEnabled()) {
+            Log.e(TAG, "Bluetooth not enabled");
+            return;
+        }
+        
+        try {
+            // 获取BluetoothA2dpSink类
+            Class<?> a2dpSinkClass = Class.forName(A2DP_SINK_CLASS);
+            
+            // 准备反射方法
+            prepareReflectionMethods(a2dpSinkClass);
+            
+            // 获取代理对象
+            boolean success = getProfileProxy();
+            if (success) {
+                Log.d(TAG, "A2DP Sink initialization started");
+            } else {
+                Log.e(TAG, "Failed to get A2DP Sink proxy");
+            }
+            
+        } catch (ClassNotFoundException e) {
+            Log.e(TAG, "BluetoothA2dpSink class not found", e);
+        } catch (Exception e) {
+            Log.e(TAG, "Error initializing A2DP Sink", e);
+        }
+    }
+    
+    /**
+     * 准备反射方法
+     */
+    private void prepareReflectionMethods(Class<?> a2dpSinkClass) throws NoSuchMethodException {
+        // 获取connect方法
+        mConnectMethod = a2dpSinkClass.getMethod("connect", BluetoothDevice.class);
+        
+        // 获取disconnect方法
+        mDisconnectMethod = a2dpSinkClass.getMethod("disconnect", BluetoothDevice.class);
+        
+        // 获取getConnectionState方法
+        mGetConnectionStateMethod = a2dpSinkClass.getMethod("getConnectionState", BluetoothDevice.class);
+        
+        // 获取getConnectedDevices方法
+        mGetConnectedDevicesMethod = a2dpSinkClass.getMethod("getConnectedDevices");
+        
+        // 获取setPriority方法（某些版本可能是setConnectionPolicy）
+        try {
+            mSetPriorityMethod = a2dpSinkClass.getMethod("setPriority", 
+                BluetoothDevice.class, int.class);
+        } catch (NoSuchMethodException e) {
+            // Android 10+使用setConnectionPolicy
+            mSetPriorityMethod = a2dpSinkClass.getMethod("setConnectionPolicy", 
+                BluetoothDevice.class, int.class);
+        }
+    }
+    
+    /**
+     * 获取BluetoothA2dpSink代理对象
+     */
+    private boolean getProfileProxy() {
+        try {
+            // 创建ServiceListener
+            BluetoothProfile.ServiceListener listener = new BluetoothProfile.ServiceListener() {
+                @Override
+                public void onServiceConnected(int profile, BluetoothProfile proxy) {
+                    Log.d(TAG, "A2DP Sink service connected");
+                    mA2dpSinkProxy = proxy;
+                    
+                    // 服务连接后的初始化
+                    onA2dpSinkReady();
+                }
+                
+                @Override
+                public void onServiceDisconnected(int profile) {
+                    Log.d(TAG, "A2DP Sink service disconnected");
+                    mA2dpSinkProxy = null;
+                }
+            };
+            
+            // 使用反射调用getProfileProxy，传入A2DP_SINK profile
+            Method getProfileProxyMethod = BluetoothAdapter.class.getMethod(
+                "getProfileProxy", Context.class, BluetoothProfile.ServiceListener.class, int.class);
+            
+            Boolean result = (Boolean) getProfileProxyMethod.invoke(
+                mBluetoothAdapter, mContext, listener, A2DP_SINK_PROFILE);
+            
+            return result != null && result;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting profile proxy", e);
+            return false;
+        }
+    }
+    
+    /**
+     * A2DP Sink服务准备就绪后的处理
+     */
+    private void onA2dpSinkReady() {
+        // 注册广播接收器
+        registerReceivers();
+        
+        // 请求音频焦点
+        requestAudioFocus();
+        
+        // 设置设备可被发现
+        makeDiscoverable();
+        
+        // 获取已连接的设备
+        getConnectedDevices();
+    }
+    
+    /**
+     * 连接到指定的蓝牙设备（作为A2DP Sink）
+     */
+    public boolean connectToDevice(BluetoothDevice device) {
+        if (mA2dpSinkProxy == null || device == null) {
+            Log.e(TAG, "A2DP Sink not ready or device is null");
+            return false;
+        }
+        
+        try {
+            // 设置设备优先级为自动连接
+            mSetPriorityMethod.invoke(mA2dpSinkProxy, device, 1000); // PRIORITY_AUTO_CONNECT
+            
+            // 连接设备
+            Boolean result = (Boolean) mConnectMethod.invoke(mA2dpSinkProxy, device);
+            Log.d(TAG, "Connect to device " + device.getAddress() + ": " + result);
+            return result != null && result;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error connecting to device", e);
+            return false;
+        }
+    }
+    
+    /**
+     * 断开与指定设备的连接
+     */
+    public boolean disconnectDevice(BluetoothDevice device) {
+        if (mA2dpSinkProxy == null || device == null) {
+            return false;
+        }
+        
+        try {
+            Boolean result = (Boolean) mDisconnectMethod.invoke(mA2dpSinkProxy, device);
+            Log.d(TAG, "Disconnect from device " + device.getAddress() + ": " + result);
+            return result != null && result;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error disconnecting device", e);
+            return false;
+        }
+    }
+    
+    /**
+     * 获取设备连接状态
+     */
+    public int getConnectionState(BluetoothDevice device) {
+        if (mA2dpSinkProxy == null || device == null) {
+            return BluetoothProfile.STATE_DISCONNECTED;
+        }
+        
+        try {
+            Integer state = (Integer) mGetConnectionStateMethod.invoke(mA2dpSinkProxy, device);
+            return state != null ? state : BluetoothProfile.STATE_DISCONNECTED;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting connection state", e);
+            return BluetoothProfile.STATE_DISCONNECTED;
+        }
+    }
+    
+    /**
+     * 获取已连接的设备列表
+     */
+    @SuppressWarnings("unchecked")
+    public List<BluetoothDevice> getConnectedDevices() {
+        if (mA2dpSinkProxy == null) {
+            return null;
+        }
+        
+        try {
+            List<BluetoothDevice> devices = (List<BluetoothDevice>) 
+                mGetConnectedDevicesMethod.invoke(mA2dpSinkProxy);
+            
+            if (devices != null) {
+                for (BluetoothDevice device : devices) {
+                    Log.d(TAG, "Connected device: " + device.getName() + 
+                        " (" + device.getAddress() + ")");
+                }
+            }
+            return devices;
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting connected devices", e);
+            return null;
+        }
+    }
+    
+    /**
+     * 请求音频焦点
+     */
+    private void requestAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            AudioAttributes attributes = new AudioAttributes.Builder()
+                .setUsage(AudioAttributes.USAGE_MEDIA)
+                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                .build();
+            
+            mFocusRequest = new AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                .setAudioAttributes(attributes)
+                .setAcceptsDelayedFocusGain(true)
+                .setOnAudioFocusChangeListener(new AudioManager.OnAudioFocusChangeListener() {
+                    @Override
+                    public void onAudioFocusChange(int focusChange) {
+                        handleAudioFocusChange(focusChange);
+                    }
+                })
+                .build();
+            
+            int result = mAudioManager.requestAudioFocus(mFocusRequest);
+            Log.d(TAG, "Audio focus request result: " + result);
+        } else {
+            // Android 8.0以下版本
+            int result = mAudioManager.requestAudioFocus(
+                new AudioManager.OnAudioFocusChangeListener() {
+                    @Override
+                    public void onAudioFocusChange(int focusChange) {
+                        handleAudioFocusChange(focusChange);
+                    }
+                },
+                AudioManager.STREAM_MUSIC,
+                AudioManager.AUDIOFOCUS_GAIN
+            );
+            Log.d(TAG, "Audio focus request result: " + result);
+        }
+    }
+    
+    /**
+     * 处理音频焦点变化
+     */
+    private void handleAudioFocusChange(int focusChange) {
+        switch (focusChange) {
+            case AudioManager.AUDIOFOCUS_GAIN:
+                Log.d(TAG, "Audio focus gained");
+                // 恢复播放
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS:
+                Log.d(TAG, "Audio focus lost");
+                // 停止播放
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
+                Log.d(TAG, "Audio focus lost transient");
+                // 暂停播放
+                break;
+            case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK:
+                Log.d(TAG, "Audio focus lost transient can duck");
+                // 降低音量
+                break;
+        }
+    }
+    
+    /**
+     * 使设备可被发现
+     */
+    private void makeDiscoverable() {
+        Intent discoverableIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_DISCOVERABLE);
+        discoverableIntent.putExtra(BluetoothAdapter.EXTRA_DISCOVERABLE_DURATION, 300);
+        discoverableIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        mContext.startActivity(discoverableIntent);
+    }
+    
+    /**
+     * 注册广播接收器
+     */
+    private void registerReceivers() {
+        IntentFilter filter = new IntentFilter();
+        
+        // A2DP Sink连接状态变化
+        filter.addAction("android.bluetooth.a2dp-sink.profile.action.CONNECTION_STATE_CHANGED");
+        
+        // 音频配置变化
+        filter.addAction("android.bluetooth.a2dp-sink.profile.action.AUDIO_CONFIG_CHANGED");
+        
+        // 播放状态变化
+        filter.addAction("android.bluetooth.a2dp-sink.profile.action.PLAYING_STATE_CHANGED");
+        
+        // 蓝牙设备连接状态
+        filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
+        filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
+        
+        mContext.registerReceiver(mA2dpSinkReceiver, filter);
+    }
+    
+    /**
+     * 广播接收器
+     */
+    private final BroadcastReceiver mA2dpSinkReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            
+            if ("android.bluetooth.a2dp-sink.profile.action.CONNECTION_STATE_CHANGED".equals(action)) {
+                int state = intent.getIntExtra(BluetoothProfile.EXTRA_STATE, -1);
+                BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                
+                Log.d(TAG, "A2DP Sink connection state changed: " + state);
+                if (device != null) {
+                    Log.d(TAG, "Device: " + device.getName() + " (" + device.getAddress() + ")");
+                }
+                
+                switch (state) {
+                    case BluetoothProfile.STATE_CONNECTED:
+                        onDeviceConnected(device);
+                        break;
+                    case BluetoothProfile.STATE_DISCONNECTED:
+                        onDeviceDisconnected(device);
+                        break;
+                }
+                
+            } else if ("android.bluetooth.a2dp-sink.profile.action.PLAYING_STATE_CHANGED".equals(action)) {
+                int state = intent.getIntExtra("android.bluetooth.a2dp-sink.extra.PLAYING_STATE", -1);
+                Log.d(TAG, "Playing state changed: " + state);
+                
+            } else if ("android.bluetooth.a2dp-sink.profile.action.AUDIO_CONFIG_CHANGED".equals(action)) {
+                BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+                int sampleRate = intent.getIntExtra("android.bluetooth.a2dp-sink.extra.SAMPLE_RATE", 0);
+                int channelCount = intent.getIntExtra("android.bluetooth.a2dp-sink.extra.CHANNEL_COUNT", 0);
+                
+                Log.d(TAG, "Audio config changed - Sample rate: " + sampleRate + 
+                    ", Channels: " + channelCount);
+            }
+        }
+    };
+    
+    /**
+     * 设备连接成功回调
+     */
+    private void onDeviceConnected(BluetoothDevice device) {
+        Log.d(TAG, "Device connected as audio source: " + device.getName());
+        // 可以在这里开始音频播放处理
+    }
+    
+    /**
+     * 设备断开连接回调
+     */
+    private void onDeviceDisconnected(BluetoothDevice device) {
+        Log.d(TAG, "Device disconnected: " + device.getName());
+        // 停止音频播放处理
+    }
+    
+    /**
+     * 清理资源
+     */
+    public void cleanup() {
+        try {
+            // 注销广播接收器
+            mContext.unregisterReceiver(mA2dpSinkReceiver);
+            
+            // 释放音频焦点
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && mFocusRequest != null) {
+                mAudioManager.abandonAudioFocusRequest(mFocusRequest);
+            } else {
+                mAudioManager.abandonAudioFocus(null);
+            }
+            
+            // 关闭代理连接
+            if (mA2dpSinkProxy != null && mBluetoothAdapter != null) {
+                Method closeProxyMethod = BluetoothAdapter.class.getMethod(
+                    "closeProfileProxy", int.class, BluetoothProfile.class);
+                closeProxyMethod.invoke(mBluetoothAdapter, A2DP_SINK_PROFILE, mA2dpSinkProxy);
+                mA2dpSinkProxy = null;
+            }
+            
+        } catch (Exception e) {
+            Log.e(TAG, "Error during cleanup", e);
+        }
+    }
+}

--- a/README_A2dpSink.md
+++ b/README_A2dpSink.md
@@ -1,0 +1,125 @@
+# BluetoothA2dpSink API 使用指南
+
+## 概述
+BluetoothA2dpSink 允许Android设备作为蓝牙音频接收器（类似蓝牙音箱），接收其他设备发送的音频流。
+
+## 重要说明
+
+### 权限要求
+1. **系统签名**：大部分功能需要系统签名（android.uid.system）
+2. **Root权限**：某些操作可能需要Root权限
+3. **特殊权限**：需要BLUETOOTH_PRIVILEGED等系统级权限
+
+### API可用性
+- BluetoothA2dpSink是**隐藏API**（@hide），不在公开SDK中
+- 需要通过反射访问
+- 不同Android版本API可能有变化
+- 部分厂商可能完全禁用此功能
+
+## 核心功能实现
+
+### 1. 初始化A2DP Sink服务
+```java
+// 通过反射获取BluetoothA2dpSink类
+Class<?> a2dpSinkClass = Class.forName("android.bluetooth.BluetoothA2dpSink");
+
+// 获取Profile代理
+int A2DP_SINK_PROFILE = 11; // Profile ID
+BluetoothAdapter.getProfileProxy(context, serviceListener, A2DP_SINK_PROFILE);
+```
+
+### 2. 主要方法（通过反射调用）
+- `connect(BluetoothDevice device)` - 连接设备
+- `disconnect(BluetoothDevice device)` - 断开连接
+- `getConnectionState(BluetoothDevice device)` - 获取连接状态
+- `getConnectedDevices()` - 获取已连接设备列表
+- `setPriority/setConnectionPolicy(BluetoothDevice device, int priority)` - 设置连接优先级
+
+### 3. 广播接收器
+监听以下Intent Action：
+- `android.bluetooth.a2dp-sink.profile.action.CONNECTION_STATE_CHANGED`
+- `android.bluetooth.a2dp-sink.profile.action.PLAYING_STATE_CHANGED`
+- `android.bluetooth.a2dp-sink.profile.action.AUDIO_CONFIG_CHANGED`
+
+### 4. 音频数据处理
+接收到的音频数据通常是SBC编码，需要：
+1. 解码SBC数据为PCM
+2. 使用AudioTrack播放PCM数据
+3. 管理音频焦点
+
+## 使用限制
+
+### 系统限制
+1. **Android版本**：Android 5.0+支持，但实现差异大
+2. **厂商定制**：许多厂商禁用或修改了此功能
+3. **设备角色**：不能同时作为A2DP Source和Sink
+
+### 技术限制
+1. **音频延迟**：蓝牙音频固有延迟（100-300ms）
+2. **音质限制**：受SBC编码限制
+3. **连接数量**：通常只支持单个音频源连接
+
+### 应用发布限制
+1. **Google Play**：使用隐藏API可能导致应用被拒
+2. **设备兼容**：只在特定设备上工作
+3. **系统更新**：系统更新可能破坏功能
+
+## 替代方案
+
+### 1. 官方支持的方案
+- **Companion Device Manager**：配对和管理蓝牙设备
+- **AudioPlaybackCapture API**：捕获其他应用音频（Android 10+）
+- **MediaProjection**：屏幕和音频录制
+
+### 2. 第三方解决方案
+- **网络音频流**：DLNA、AirPlay、Chromecast
+- **自定义协议**：通过WiFi Direct或经典蓝牙SPP传输
+
+### 3. 硬件方案
+- **USB音频**：通过USB OTG实现音频输入
+- **外部蓝牙模块**：使用支持A2DP Sink的蓝牙模块
+
+## 开发建议
+
+### 测试设备
+1. **推荐设备**：
+   - Pixel系列（原生Android）
+   - 已Root的设备
+   - Android Things设备
+
+2. **测试方法**：
+   - 使用ADB检查服务可用性
+   - 测试不同Android版本
+   - 验证音频质量和延迟
+
+### 最佳实践
+1. **错误处理**：充分的异常捕获和降级处理
+2. **用户提示**：明确告知功能限制
+3. **电池优化**：合理管理后台服务
+4. **音频管理**：正确处理音频焦点和路由
+
+## 示例项目结构
+```
+BluetoothA2dpSinkDemo/
+├── BluetoothA2dpSinkDemo.java    # 核心A2DP Sink实现
+├── A2dpSinkActivity.java         # 演示UI
+├── A2dpSinkAudioHandler.java     # 音频处理
+└── AndroidManifest.xml            # 权限配置
+```
+
+## 注意事项
+⚠️ **此功能主要用于**：
+- 企业内部应用
+- 定制ROM开发
+- 特定硬件产品
+- 研究和学习目的
+
+⚠️ **不适用于**：
+- 普通消费者应用
+- Google Play发布
+- 需要广泛兼容的应用
+
+## 相关资源
+- [Android Bluetooth官方文档](https://developer.android.com/guide/topics/connectivity/bluetooth)
+- [AOSP源码 - BluetoothA2dpSink](https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/bluetooth/)
+- [A2DP规范](https://www.bluetooth.com/specifications/specs/)


### PR DESCRIPTION
Implement a demonstration of `BluetoothA2dpSink` API usage to allow an Android device to act as a Bluetooth audio receiver, addressing the user's query on virtual Bluetooth audio devices.

This implementation uses reflection to access the hidden `BluetoothA2dpSink` API, which typically requires system-level permissions (system signature or root) and is not intended for standard consumer applications. It includes core A2DP Sink management, UI for device interaction, and an audio handler for SBC decoding and playback, highlighting the technical complexities and limitations discussed in the conversation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2af60c11-29c5-4d39-9591-4325c159e73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2af60c11-29c5-4d39-9591-4325c159e73a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

