### PR TITLE
Handle media projection foreground service requirement

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.example.usbaudiocapture">
+
+    <!-- Permissions -->
+    <!-- Required for MediaProjection -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    
+    <!-- Required for foreground service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    
+    <!-- Required for MediaProjection foreground service (Android 14+) -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+    
+    <!-- Optional: For notification channels and system alerts -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    
+    <!-- Optional: For accessing USB devices -->
+    <uses-permission android:name="android.permission.USB_PERMISSION" />
+    <uses-feature android:name="android.hardware.usb.host" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.AppCompat">
+
+        <!-- Main Activity -->
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- MediaProjection Foreground Service -->
+        <service
+            android:name=".MediaProjectionService"
+            android:enabled="true"
+            android:exported="false"
+            android:foregroundServiceType="mediaProjection"
+            tools:targetApi="q">
+            <!-- 
+                The foregroundServiceType="mediaProjection" is crucial for Android 10+ 
+                This tells the system that this service will be using MediaProjection API
+            -->
+        </service>
+
+        <!-- Optional: USB Device Receiver -->
+        <receiver
+            android:name=".UsbReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" />
+                <action android:name="android.hardware.usb.action.USB_DEVICE_DETACHED" />
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/device_filter" />
+        </receiver>
+
+    </application>
+
+</manifest>

--- a/MainActivity.uts
+++ b/MainActivity.uts
@@ -1,0 +1,257 @@
+import { Activity } from 'android.app.Activity'
+import { Bundle } from 'android.os.Bundle'
+import { Intent } from 'android.content.Intent'
+import { View } from 'android.view.View'
+import { Button } from 'android.widget.Button'
+import { TextView } from 'android.widget.TextView'
+import { LinearLayout } from 'android.widget.LinearLayout'
+import { ViewGroup } from 'android.view.ViewGroup'
+import { Gravity } from 'android.view.Gravity'
+import { Toast } from 'android.widget.Toast'
+import { PackageManager } from 'android.content.pm.PackageManager'
+import { Manifest } from 'android.Manifest'
+import { Build } from 'android.os.Build'
+import { ActivityCompat } from 'androidx.core.app.ActivityCompat'
+import { ContextCompat } from 'androidx.core.content.ContextCompat'
+import { Log } from 'android.util.Log'
+
+export class MainActivity extends Activity {
+    private static TAG = "MainActivity"
+    private static REQUEST_PERMISSIONS = 100
+    private static REQUEST_MEDIA_PROJECTION = 1001
+    
+    private usbAudioManager: UsbAudioManager | null = null
+    private statusTextView: TextView | null = null
+    private startButton: Button | null = null
+    private stopButton: Button | null = null
+    
+    override onCreate(savedInstanceState: Bundle | null): void {
+        super.onCreate(savedInstanceState)
+        
+        // Create UI
+        this.setupUI()
+        
+        // Initialize USB Audio Manager
+        this.usbAudioManager = new UsbAudioManager(this)
+        
+        // Check and request permissions
+        this.checkPermissions()
+    }
+    
+    /**
+     * Setup the user interface
+     */
+    private setupUI(): void {
+        // Create main layout
+        val layout = new LinearLayout(this)
+        layout.setOrientation(LinearLayout.VERTICAL)
+        layout.setGravity(Gravity.CENTER)
+        layout.setPadding(20, 20, 20, 20)
+        
+        // Create status text view
+        this.statusTextView = new TextView(this)
+        this.statusTextView.setText("Ready to start audio capture")
+        this.statusTextView.setTextSize(18)
+        this.statusTextView.setPadding(0, 20, 0, 20)
+        
+        // Create start button
+        this.startButton = new Button(this)
+        this.startButton.setText("Start Audio Capture")
+        this.startButton.setOnClickListener(new View.OnClickListener() {
+            override onClick(v: View): void {
+                this@MainActivity.startAudioCapture()
+            }
+        })
+        
+        // Create stop button
+        this.stopButton = new Button(this)
+        this.stopButton.setText("Stop Audio Capture")
+        this.stopButton.setEnabled(false)
+        this.stopButton.setOnClickListener(new View.OnClickListener() {
+            override onClick(v: View): void {
+                this@MainActivity.stopAudioCapture()
+            }
+        })
+        
+        // Add views to layout
+        layout.addView(this.statusTextView)
+        layout.addView(this.startButton)
+        layout.addView(this.stopButton)
+        
+        // Set content view
+        this.setContentView(layout)
+    }
+    
+    /**
+     * Check and request necessary permissions
+     */
+    private checkPermissions(): void {
+        val permissions = mutableListOf<String>()
+        
+        // Check RECORD_AUDIO permission
+        if (ContextCompat.checkSelfPermission(this, Manifest.permission.RECORD_AUDIO) 
+            != PackageManager.PERMISSION_GRANTED) {
+            permissions.add(Manifest.permission.RECORD_AUDIO)
+        }
+        
+        // Check FOREGROUND_SERVICE permission (Android P+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.FOREGROUND_SERVICE) 
+                != PackageManager.PERMISSION_GRANTED) {
+                permissions.add(Manifest.permission.FOREGROUND_SERVICE)
+            }
+        }
+        
+        // Check POST_NOTIFICATIONS permission (Android 13+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, "android.permission.POST_NOTIFICATIONS") 
+                != PackageManager.PERMISSION_GRANTED) {
+                permissions.add("android.permission.POST_NOTIFICATIONS")
+            }
+        }
+        
+        // Request permissions if needed
+        if (permissions.isNotEmpty()) {
+            ActivityCompat.requestPermissions(
+                this,
+                permissions.toTypedArray(),
+                MainActivity.REQUEST_PERMISSIONS
+            )
+        } else {
+            Log.d(MainActivity.TAG, "All permissions granted")
+            this.updateStatus("Permissions granted. Ready to start.")
+        }
+    }
+    
+    /**
+     * Handle permission request results
+     */
+    override onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<String>,
+        grantResults: IntArray
+    ): void {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        
+        if (requestCode == MainActivity.REQUEST_PERMISSIONS) {
+            var allGranted = true
+            
+            for (i in 0 until grantResults.length) {
+                if (grantResults[i] != PackageManager.PERMISSION_GRANTED) {
+                    allGranted = false
+                    Log.e(MainActivity.TAG, "Permission denied: " + permissions[i])
+                }
+            }
+            
+            if (allGranted) {
+                Log.d(MainActivity.TAG, "All permissions granted")
+                this.updateStatus("Permissions granted. Ready to start.")
+            } else {
+                this.updateStatus("Some permissions denied. Audio capture may not work properly.")
+                Toast.makeText(
+                    this,
+                    "Please grant all permissions for audio capture to work",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+    
+    /**
+     * Start audio capture
+     */
+    private startAudioCapture(): void {
+        Log.d(MainActivity.TAG, "Starting audio capture")
+        this.updateStatus("Initializing MediaProjection...")
+        
+        // Initialize MediaProjection (this will request permission and start the service)
+        this.usbAudioManager?.initializeMediaProjection()
+        
+        // Update UI
+        this.startButton?.setEnabled(false)
+    }
+    
+    /**
+     * Stop audio capture
+     */
+    private stopAudioCapture(): void {
+        Log.d(MainActivity.TAG, "Stopping audio capture")
+        
+        // Stop recording
+        this.usbAudioManager?.stopRecording()
+        
+        // Update UI
+        this.updateStatus("Audio capture stopped")
+        this.startButton?.setEnabled(true)
+        this.stopButton?.setEnabled(false)
+    }
+    
+    /**
+     * Handle activity result (for MediaProjection permission)
+     */
+    override onActivityResult(requestCode: Int, resultCode: Int, data: Intent | null): void {
+        super.onActivityResult(requestCode, resultCode, data)
+        
+        if (requestCode == MainActivity.REQUEST_MEDIA_PROJECTION) {
+            if (resultCode == RESULT_OK && data != null) {
+                Log.d(MainActivity.TAG, "MediaProjection permission granted")
+                this.updateStatus("MediaProjection permission granted. Starting capture...")
+                
+                // Pass the result to UsbAudioManager
+                this.usbAudioManager?.handleActivityResult(requestCode, resultCode, data)
+                
+                // Start recording after a short delay
+                this.postDelayed({
+                    if (this.usbAudioManager?.isMediaProjectionAvailable() == true) {
+                        if (this.usbAudioManager?.startRecording() == true) {
+                            this.updateStatus("Audio capture started")
+                            this.stopButton?.setEnabled(true)
+                        } else {
+                            this.updateStatus("Failed to start recording")
+                            this.startButton?.setEnabled(true)
+                        }
+                    } else {
+                        this.updateStatus("MediaProjection not available")
+                        this.startButton?.setEnabled(true)
+                    }
+                }, 1000)
+            } else {
+                Log.e(MainActivity.TAG, "MediaProjection permission denied")
+                this.updateStatus("Permission denied. Cannot capture audio.")
+                this.startButton?.setEnabled(true)
+                
+                Toast.makeText(
+                    this,
+                    "Screen recording permission is required for audio capture",
+                    Toast.LENGTH_LONG
+                ).show()
+            }
+        }
+    }
+    
+    /**
+     * Update status text
+     */
+    private updateStatus(status: String): void {
+        this.runOnUiThread({
+            this.statusTextView?.setText(status)
+        })
+    }
+    
+    /**
+     * Post delayed action
+     */
+    private postDelayed(action: () -> void, delayMillis: Long): void {
+        this.statusTextView?.postDelayed(action, delayMillis)
+    }
+    
+    override onDestroy(): void {
+        super.onDestroy()
+        
+        // Release resources
+        this.usbAudioManager?.release()
+        this.usbAudioManager = null
+        
+        Log.d(MainActivity.TAG, "Activity destroyed")
+    }
+}

--- a/README_MEDIAPROJECTION_FIX.md
+++ b/README_MEDIAPROJECTION_FIX.md
@@ -1,0 +1,141 @@
+# MediaProjection Foreground Service Fix
+
+## Problem
+The error `java.lang.SecurityException: Media projections require a foreground service of type ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION` occurs when trying to use MediaProjection API without a properly configured foreground service.
+
+## Solution Overview
+Starting from Android 10 (API 29), MediaProjection requires a foreground service with the specific type `FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION`. This implementation provides a complete solution with:
+
+1. **MediaProjectionService** - A foreground service that handles MediaProjection lifecycle
+2. **UsbAudioManager** - Main class that manages audio capture using MediaProjection
+3. **MainActivity** - Sample activity demonstrating proper usage
+4. **AndroidManifest.xml** - Proper permissions and service declarations
+
+## Key Components
+
+### 1. MediaProjectionService (`MediaProjectionService.uts`)
+- Implements a foreground service with `FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION`
+- Creates and manages MediaProjection instances safely
+- Handles notification requirements for foreground services
+- Provides proper lifecycle management
+
+### 2. UsbAudioManager (`usb-audio-manager.uts`)
+- Manages the entire audio capture workflow
+- Starts and binds to MediaProjectionService before creating MediaProjection
+- Implements AudioRecord with AudioPlaybackCaptureConfiguration (API 29+)
+- Handles audio data processing in a separate thread
+
+### 3. Permissions Required
+```xml
+<!-- Core permissions -->
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+
+<!-- Required for Android 14+ -->
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
+
+<!-- Optional but recommended -->
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+### 4. Service Declaration in AndroidManifest.xml
+```xml
+<service
+    android:name=".MediaProjectionService"
+    android:enabled="true"
+    android:exported="false"
+    android:foregroundServiceType="mediaProjection"
+    tools:targetApi="q">
+</service>
+```
+
+## Implementation Flow
+
+1. **Permission Check**: Request RECORD_AUDIO and other necessary permissions
+2. **Start Foreground Service**: Start MediaProjectionService before requesting MediaProjection
+3. **Request MediaProjection**: Show system dialog for screen recording permission
+4. **Create MediaProjection**: Use the service to create MediaProjection instance
+5. **Setup AudioCapture**: Configure AudioRecord with AudioPlaybackCaptureConfiguration
+6. **Start Recording**: Begin capturing audio in a background thread
+7. **Process Audio**: Handle captured audio data (send to USB, save to file, etc.)
+8. **Cleanup**: Properly stop and release all resources
+
+## API Level Requirements
+
+- **Minimum**: API 21 (Android 5.0) for basic MediaProjection
+- **Recommended**: API 29 (Android 10) for AudioPlaybackCapture
+- **Full Support**: API 29+ for all features including foreground service type
+
+## Error Handling
+
+The implementation includes comprehensive error handling for:
+- Missing permissions
+- Service binding failures
+- MediaProjection creation failures
+- AudioRecord initialization errors
+- Thread interruptions
+
+## Usage Example
+
+```typescript
+// Initialize the manager
+const audioManager = new UsbAudioManager(context)
+
+// Start MediaProjection (will show permission dialog)
+audioManager.initializeMediaProjection()
+
+// Handle the result in onActivityResult
+override onActivityResult(requestCode: Int, resultCode: Int, data: Intent | null): void {
+    audioManager.handleActivityResult(requestCode, resultCode, data)
+}
+
+// Start recording when ready
+if (audioManager.isMediaProjectionAvailable()) {
+    audioManager.startRecording()
+}
+
+// Stop recording
+audioManager.stopRecording()
+
+// Clean up
+audioManager.release()
+```
+
+## Testing Checklist
+
+- [ ] Verify all permissions are granted
+- [ ] Check notification appears when service starts
+- [ ] Confirm MediaProjection permission dialog shows
+- [ ] Test audio capture starts without crashes
+- [ ] Verify audio data is being received
+- [ ] Check proper cleanup on app exit
+- [ ] Test on different Android versions (especially 10+)
+
+## Troubleshooting
+
+1. **Still getting SecurityException**: 
+   - Ensure service is started before creating MediaProjection
+   - Verify `foregroundServiceType="mediaProjection"` in manifest
+   - Check Android version compatibility
+
+2. **Service not starting**:
+   - Check FOREGROUND_SERVICE permission
+   - Verify notification channel creation for Android O+
+   - Ensure proper PendingIntent flags
+
+3. **No audio captured**:
+   - Verify RECORD_AUDIO permission
+   - Check AudioRecord state after initialization
+   - Ensure API level is 29+ for AudioPlaybackCapture
+
+4. **App crashes on Android 14+**:
+   - Add FOREGROUND_SERVICE_MEDIA_PROJECTION permission
+   - Update targetSdk and compileSdk appropriately
+
+## Notes
+
+- The foreground service will show a persistent notification while active
+- Users must grant screen recording permission for audio capture to work
+- Audio capture may not work with DRM-protected content
+- Some apps may prevent their audio from being captured
+- Battery optimization may affect long-running capture sessions

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,53 @@
+// build.gradle (Module: app)
+
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.example.usbaudiocapture'
+    compileSdk 34  // Use latest SDK for Android 14 support
+
+    defaultConfig {
+        applicationId "com.example.usbaudiocapture"
+        minSdk 21  // MediaProjection minimum
+        targetSdk 34  // Target latest Android version
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        debug {
+            debuggable true
+        }
+    }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+}
+
+dependencies {
+    // AndroidX Core libraries
+    implementation 'androidx.core:core:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    
+    // Material Design
+    implementation 'com.google.android.material:material:1.11.0'
+    
+    // For better permission handling
+    implementation 'androidx.activity:activity:1.8.2'
+    implementation 'androidx.fragment:fragment:1.6.2'
+    
+    // Testing
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/pages/index/MediaProjectionService.uts
+++ b/pages/index/MediaProjectionService.uts
@@ -1,0 +1,219 @@
+import { Service } from 'android.app.Service'
+import { Notification } from 'android.app.Notification'
+import { NotificationChannel } from 'android.app.NotificationChannel'
+import { NotificationManager } from 'android.app.NotificationManager'
+import { PendingIntent } from 'android.app.PendingIntent'
+import { Intent } from 'android.content.Intent'
+import { IBinder } from 'android.os.IBinder'
+import { Binder } from 'android.os.Binder'
+import { Build } from 'android.os.Build'
+import { ServiceInfo } from 'android.content.pm.ServiceInfo'
+import { MediaProjection } from 'android.media.projection.MediaProjection'
+import { MediaProjectionManager } from 'android.media.projection.MediaProjectionManager'
+import { Log } from 'android.util.Log'
+import { R } from 'android.R'
+
+export class MediaProjectionService extends Service {
+    private static TAG = "MediaProjectionService"
+    private static CHANNEL_ID = "MediaProjectionChannel"
+    private static NOTIFICATION_ID = 1
+    
+    private binder: LocalBinder = new LocalBinder()
+    private mediaProjection: MediaProjection | null = null
+    
+    /**
+     * Binder class for local service binding
+     */
+    public class LocalBinder extends Binder {
+        public getService(): MediaProjectionService {
+            return MediaProjectionService.this
+        }
+    }
+    
+    override onCreate(): void {
+        super.onCreate()
+        Log.d(MediaProjectionService.TAG, "Service created")
+        this.createNotificationChannel()
+    }
+    
+    override onStartCommand(intent: Intent | null, flags: Int, startId: Int): Int {
+        Log.d(MediaProjectionService.TAG, "Service started")
+        this.startForegroundService()
+        return Service.START_STICKY
+    }
+    
+    override onBind(intent: Intent): IBinder {
+        Log.d(MediaProjectionService.TAG, "Service bound")
+        return this.binder
+    }
+    
+    override onUnbind(intent: Intent): Boolean {
+        Log.d(MediaProjectionService.TAG, "Service unbound")
+        return super.onUnbind(intent)
+    }
+    
+    override onDestroy(): void {
+        Log.d(MediaProjectionService.TAG, "Service destroyed")
+        this.stopMediaProjection()
+        super.onDestroy()
+    }
+    
+    /**
+     * Create notification channel for Android O and above
+     */
+    private createNotificationChannel(): void {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = new NotificationChannel(
+                MediaProjectionService.CHANNEL_ID,
+                "Media Projection Service",
+                NotificationManager.IMPORTANCE_LOW
+            )
+            channel.setDescription("Service for capturing audio using MediaProjection")
+            channel.setShowBadge(false)
+            channel.setLockscreenVisibility(Notification.VISIBILITY_PUBLIC)
+            
+            val notificationManager = this.getSystemService(NotificationManager.class) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+            
+            Log.d(MediaProjectionService.TAG, "Notification channel created")
+        }
+    }
+    
+    /**
+     * Start the service as a foreground service with proper type
+     */
+    private startForegroundService(): void {
+        val notification = this.createNotification()
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // For Android Q (API 29) and above, specify the service type
+            try {
+                this.startForeground(
+                    MediaProjectionService.NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                )
+                Log.d(MediaProjectionService.TAG, "Started foreground service with MEDIA_PROJECTION type")
+            } catch (e: Exception) {
+                Log.e(MediaProjectionService.TAG, "Error starting foreground service: " + e.getMessage())
+                e.printStackTrace()
+                // Fallback to regular foreground service
+                this.startForeground(MediaProjectionService.NOTIFICATION_ID, notification)
+            }
+        } else {
+            // For older Android versions
+            this.startForeground(MediaProjectionService.NOTIFICATION_ID, notification)
+            Log.d(MediaProjectionService.TAG, "Started foreground service (legacy)")
+        }
+    }
+    
+    /**
+     * Create notification for the foreground service
+     */
+    private createNotification(): Notification {
+        val builder: Notification.Builder
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            builder = new Notification.Builder(this, MediaProjectionService.CHANNEL_ID)
+        } else {
+            builder = new Notification.Builder(this)
+        }
+        
+        // Create a pending intent for notification tap
+        val notificationIntent = new Intent(this, this.getClass())
+        val pendingIntentFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        } else {
+            PendingIntent.FLAG_UPDATE_CURRENT
+        }
+        val pendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, pendingIntentFlags)
+        
+        // Build the notification
+        builder.setContentTitle("Audio Capture Service")
+            .setContentText("Capturing system audio...")
+            .setSmallIcon(R.drawable.ic_media_play) // Using system icon as fallback
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            builder.setCategory(Notification.CATEGORY_SERVICE)
+                .setVisibility(Notification.VISIBILITY_PUBLIC)
+        }
+        
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            builder.setChannelId(MediaProjectionService.CHANNEL_ID)
+        }
+        
+        return builder.build()
+    }
+    
+    /**
+     * Create MediaProjection instance
+     */
+    public createMediaProjection(
+        manager: MediaProjectionManager,
+        resultCode: Int,
+        data: Intent
+    ): MediaProjection | null {
+        try {
+            // Stop any existing projection
+            this.stopMediaProjection()
+            
+            // Create new MediaProjection
+            this.mediaProjection = manager.getMediaProjection(resultCode, data)
+            
+            if (this.mediaProjection != null) {
+                // Register callback for MediaProjection lifecycle
+                this.mediaProjection.registerCallback(new MediaProjection.Callback() {
+                    override onStop(): void {
+                        Log.d(MediaProjectionService.TAG, "MediaProjection stopped")
+                        MediaProjectionService.this.mediaProjection = null
+                    }
+                }, null)
+                
+                Log.d(MediaProjectionService.TAG, "MediaProjection created successfully")
+            } else {
+                Log.e(MediaProjectionService.TAG, "Failed to create MediaProjection")
+            }
+            
+            return this.mediaProjection
+        } catch (e: SecurityException) {
+            Log.e(MediaProjectionService.TAG, "SecurityException creating MediaProjection: " + e.getMessage())
+            e.printStackTrace()
+            return null
+        } catch (e: Exception) {
+            Log.e(MediaProjectionService.TAG, "Exception creating MediaProjection: " + e.getMessage())
+            e.printStackTrace()
+            return null
+        }
+    }
+    
+    /**
+     * Stop MediaProjection
+     */
+    public stopMediaProjection(): void {
+        if (this.mediaProjection != null) {
+            try {
+                this.mediaProjection.stop()
+                this.mediaProjection = null
+                Log.d(MediaProjectionService.TAG, "MediaProjection stopped")
+            } catch (e: Exception) {
+                Log.e(MediaProjectionService.TAG, "Error stopping MediaProjection: " + e.getMessage())
+            }
+        }
+    }
+    
+    /**
+     * Get current MediaProjection instance
+     */
+    public getMediaProjection(): MediaProjection | null {
+        return this.mediaProjection
+    }
+    
+    /**
+     * Check if MediaProjection is active
+     */
+    public isProjectionActive(): Boolean {
+        return this.mediaProjection != null
+    }
+}

--- a/pages/index/usb-audio-manager.uts
+++ b/pages/index/usb-audio-manager.uts
@@ -1,0 +1,384 @@
+import { Activity } from 'android.app.Activity'
+import { Context } from 'android.content.Context'
+import { Intent } from 'android.content.Intent'
+import { ServiceConnection } from 'android.content.ServiceConnection'
+import { ComponentName } from 'android.content.ComponentName'
+import { IBinder } from 'android.os.IBinder'
+import { Build } from 'android.os.Build'
+import { MediaProjection } from 'android.media.projection.MediaProjection'
+import { MediaProjectionManager } from 'android.media.projection.MediaProjectionManager'
+import { AudioManager } from 'android.media.AudioManager'
+import { AudioFormat } from 'android.media.AudioFormat'
+import { AudioRecord } from 'android.media.AudioRecord'
+import { AudioAttributes } from 'android.media.AudioAttributes'
+import { AudioPlaybackCaptureConfiguration } from 'android.media.AudioPlaybackCaptureConfiguration'
+import { MediaRecorder } from 'android.media.MediaRecorder'
+import { Handler } from 'android.os.Handler'
+import { Looper } from 'android.os.Looper'
+import { Log } from 'android.util.Log'
+
+export class UsbAudioManager {
+    private static TAG = "UsbAudioManager"
+    private context: Context | null = null
+    private activity: Activity | null = null
+    private mediaProjectionManager: MediaProjectionManager | null = null
+    private mediaProjection: MediaProjection | null = null
+    private audioRecord: AudioRecord | null = null
+    private isRecording = false
+    private recordingThread: Thread | null = null
+    
+    // Service related
+    private mediaProjectionService: MediaProjectionService | null = null
+    private serviceConnection: ServiceConnection | null = null
+    private isBound = false
+    
+    // Audio configuration
+    private sampleRate = 44100
+    private channelConfig = AudioFormat.CHANNEL_IN_STEREO
+    private audioFormat = AudioFormat.ENCODING_PCM_16BIT
+    private bufferSize = 0
+    
+    // Request codes
+    private static REQUEST_MEDIA_PROJECTION = 1001
+    
+    constructor(context: Context) {
+        this.context = context
+        if (context instanceof Activity) {
+            this.activity = context as Activity
+        }
+        this.initializeAudioConfiguration()
+        this.initializeServiceConnection()
+    }
+    
+    private initializeAudioConfiguration(): void {
+        this.bufferSize = AudioRecord.getMinBufferSize(
+            this.sampleRate,
+            this.channelConfig,
+            this.audioFormat
+        )
+        
+        if (this.bufferSize == AudioRecord.ERROR || this.bufferSize == AudioRecord.ERROR_BAD_VALUE) {
+            Log.e(UsbAudioManager.TAG, "Invalid buffer size")
+            this.bufferSize = this.sampleRate * 2 // fallback buffer size
+        }
+    }
+    
+    private initializeServiceConnection(): void {
+        this.serviceConnection = new ServiceConnection() {
+            override onServiceConnected(name: ComponentName, service: IBinder): void {
+                const binder = service as MediaProjectionService.LocalBinder
+                this.mediaProjectionService = binder.getService()
+                this.isBound = true
+                Log.d(UsbAudioManager.TAG, "MediaProjection service connected")
+            }
+            
+            override onServiceDisconnected(name: ComponentName): void {
+                this.mediaProjectionService = null
+                this.isBound = false
+                Log.d(UsbAudioManager.TAG, "MediaProjection service disconnected")
+            }
+        }
+    }
+    
+    /**
+     * Start the MediaProjection service
+     */
+    private startMediaProjectionService(): void {
+        if (this.context == null) {
+            Log.e(UsbAudioManager.TAG, "Context is null")
+            return
+        }
+        
+        const serviceIntent = new Intent(this.context, MediaProjectionService.class)
+        
+        // For Android O and above, start as foreground service
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            this.context.startForegroundService(serviceIntent)
+        } else {
+            this.context.startService(serviceIntent)
+        }
+        
+        // Bind to the service
+        this.context.bindService(serviceIntent, this.serviceConnection!!, Context.BIND_AUTO_CREATE)
+    }
+    
+    /**
+     * Stop the MediaProjection service
+     */
+    private stopMediaProjectionService(): void {
+        if (this.isBound && this.context != null) {
+            this.context.unbindService(this.serviceConnection!!)
+            this.isBound = false
+        }
+        
+        if (this.context != null) {
+            const serviceIntent = new Intent(this.context, MediaProjectionService.class)
+            this.context.stopService(serviceIntent)
+        }
+    }
+    
+    /**
+     * Initialize MediaProjection
+     */
+    public initializeMediaProjection(): void {
+        if (this.context == null) {
+            Log.e(UsbAudioManager.TAG, "Context is null")
+            return
+        }
+        
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            Log.e(UsbAudioManager.TAG, "MediaProjection requires API 21+")
+            return
+        }
+        
+        this.mediaProjectionManager = this.context.getSystemService(Context.MEDIA_PROJECTION_SERVICE) as MediaProjectionManager
+        
+        if (this.mediaProjectionManager == null) {
+            Log.e(UsbAudioManager.TAG, "Failed to get MediaProjectionManager")
+            return
+        }
+        
+        // Start the foreground service first
+        this.startMediaProjectionService()
+        
+        // Request media projection permission
+        this.requestMediaProjectionPermission()
+    }
+    
+    /**
+     * Request MediaProjection permission
+     */
+    private requestMediaProjectionPermission(): void {
+        if (this.activity == null || this.mediaProjectionManager == null) {
+            Log.e(UsbAudioManager.TAG, "Activity or MediaProjectionManager is null")
+            return
+        }
+        
+        const captureIntent = this.mediaProjectionManager.createScreenCaptureIntent()
+        this.activity.startActivityForResult(captureIntent, UsbAudioManager.REQUEST_MEDIA_PROJECTION)
+    }
+    
+    /**
+     * Handle activity result for MediaProjection permission
+     */
+    public handleActivityResult(requestCode: Int, resultCode: Int, data: Intent | null): void {
+        if (requestCode == UsbAudioManager.REQUEST_MEDIA_PROJECTION) {
+            if (resultCode == Activity.RESULT_OK && data != null) {
+                // Wait for service to be bound before creating MediaProjection
+                if (this.isBound && this.mediaProjectionService != null) {
+                    this.createMediaProjection(resultCode, data)
+                } else {
+                    // Retry after a delay if service is not ready
+                    Handler(Looper.getMainLooper()).postDelayed({
+                        if (this.isBound && this.mediaProjectionService != null) {
+                            this.createMediaProjection(resultCode, data)
+                        } else {
+                            Log.e(UsbAudioManager.TAG, "Service not ready for MediaProjection")
+                        }
+                    }, 500)
+                }
+            } else {
+                Log.e(UsbAudioManager.TAG, "MediaProjection permission denied")
+                this.stopMediaProjectionService()
+            }
+        }
+    }
+    
+    /**
+     * Create MediaProjection with foreground service
+     */
+    private createMediaProjection(resultCode: Int, data: Intent): void {
+        try {
+            // Create MediaProjection through the foreground service
+            if (this.mediaProjectionService != null) {
+                this.mediaProjection = this.mediaProjectionService.createMediaProjection(
+                    this.mediaProjectionManager!!,
+                    resultCode,
+                    data
+                )
+                
+                if (this.mediaProjection != null) {
+                    Log.d(UsbAudioManager.TAG, "MediaProjection created successfully")
+                    this.setupAudioCapture()
+                } else {
+                    Log.e(UsbAudioManager.TAG, "Failed to create MediaProjection")
+                }
+            } else {
+                Log.e(UsbAudioManager.TAG, "MediaProjection service is not available")
+            }
+        } catch (e: Exception) {
+            Log.e(UsbAudioManager.TAG, "Error creating MediaProjection: " + e.getMessage())
+            e.printStackTrace()
+        }
+    }
+    
+    /**
+     * Setup audio capture with MediaProjection
+     */
+    private setupAudioCapture(): void {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            Log.e(UsbAudioManager.TAG, "Audio capture requires API 29+")
+            return
+        }
+        
+        if (this.mediaProjection == null) {
+            Log.e(UsbAudioManager.TAG, "MediaProjection is null")
+            return
+        }
+        
+        try {
+            // Create AudioPlaybackCaptureConfiguration
+            val configBuilder = AudioPlaybackCaptureConfiguration.Builder(this.mediaProjection!!)
+            configBuilder.addMatchingUsage(AudioAttributes.USAGE_MEDIA)
+            configBuilder.addMatchingUsage(AudioAttributes.USAGE_GAME)
+            configBuilder.addMatchingUsage(AudioAttributes.USAGE_UNKNOWN)
+            val config = configBuilder.build()
+            
+            // Create AudioRecord with the capture configuration
+            val audioFormatBuilder = AudioFormat.Builder()
+                .setEncoding(this.audioFormat)
+                .setSampleRate(this.sampleRate)
+                .setChannelMask(this.channelConfig)
+            
+            this.audioRecord = AudioRecord.Builder()
+                .setAudioFormat(audioFormatBuilder.build())
+                .setBufferSizeInBytes(this.bufferSize)
+                .setAudioPlaybackCaptureConfig(config)
+                .build()
+            
+            if (this.audioRecord?.getState() == AudioRecord.STATE_INITIALIZED) {
+                Log.d(UsbAudioManager.TAG, "AudioRecord initialized successfully")
+            } else {
+                Log.e(UsbAudioManager.TAG, "Failed to initialize AudioRecord")
+            }
+        } catch (e: Exception) {
+            Log.e(UsbAudioManager.TAG, "Error setting up audio capture: " + e.getMessage())
+            e.printStackTrace()
+        }
+    }
+    
+    /**
+     * Start audio recording
+     */
+    public startRecording(): Boolean {
+        if (this.audioRecord == null) {
+            Log.e(UsbAudioManager.TAG, "AudioRecord is not initialized")
+            return false
+        }
+        
+        if (this.isRecording) {
+            Log.w(UsbAudioManager.TAG, "Already recording")
+            return true
+        }
+        
+        try {
+            this.audioRecord.startRecording()
+            this.isRecording = true
+            
+            // Start recording thread
+            this.recordingThread = Thread({
+                this.recordingLoop()
+            })
+            this.recordingThread?.start()
+            
+            Log.d(UsbAudioManager.TAG, "Recording started")
+            return true
+        } catch (e: Exception) {
+            Log.e(UsbAudioManager.TAG, "Error starting recording: " + e.getMessage())
+            e.printStackTrace()
+            return false
+        }
+    }
+    
+    /**
+     * Recording loop to process audio data
+     */
+    private recordingLoop(): void {
+        val buffer = ByteArray(this.bufferSize)
+        
+        while (this.isRecording) {
+            val bytesRead = this.audioRecord?.read(buffer, 0, buffer.length) ?: 0
+            
+            if (bytesRead > 0) {
+                // Process audio data here
+                this.processAudioData(buffer, bytesRead)
+            } else if (bytesRead < 0) {
+                Log.e(UsbAudioManager.TAG, "Error reading audio data: " + bytesRead)
+            }
+        }
+    }
+    
+    /**
+     * Process captured audio data
+     */
+    private processAudioData(buffer: ByteArray, bytesRead: Int): void {
+        // TODO: Implement audio data processing
+        // This could include:
+        // - Sending to USB audio device
+        // - Saving to file
+        // - Streaming over network
+        // - Real-time processing
+        
+        Log.v(UsbAudioManager.TAG, "Processing " + bytesRead + " bytes of audio data")
+    }
+    
+    /**
+     * Stop audio recording
+     */
+    public stopRecording(): void {
+        this.isRecording = false
+        
+        // Wait for recording thread to finish
+        try {
+            this.recordingThread?.join(1000)
+        } catch (e: InterruptedException) {
+            Log.e(UsbAudioManager.TAG, "Error waiting for recording thread: " + e.getMessage())
+        }
+        
+        // Stop and release AudioRecord
+        if (this.audioRecord != null) {
+            try {
+                this.audioRecord.stop()
+                this.audioRecord.release()
+                this.audioRecord = null
+                Log.d(UsbAudioManager.TAG, "Recording stopped")
+            } catch (e: Exception) {
+                Log.e(UsbAudioManager.TAG, "Error stopping recording: " + e.getMessage())
+            }
+        }
+    }
+    
+    /**
+     * Release all resources
+     */
+    public release(): void {
+        this.stopRecording()
+        
+        if (this.mediaProjection != null) {
+            this.mediaProjection.stop()
+            this.mediaProjection = null
+        }
+        
+        this.stopMediaProjectionService()
+        
+        this.mediaProjectionManager = null
+        this.context = null
+        this.activity = null
+        
+        Log.d(UsbAudioManager.TAG, "Resources released")
+    }
+    
+    /**
+     * Check if currently recording
+     */
+    public isRecording(): Boolean {
+        return this.isRecording
+    }
+    
+    /**
+     * Check if MediaProjection is available
+     */
+    public isMediaProjectionAvailable(): Boolean {
+        return this.mediaProjection != null
+    }
+}


### PR DESCRIPTION
Implement MediaProjection with a foreground service to resolve `SecurityException` on Android 10+.

The `SecurityException` occurs because Android 10 (API 29) and above require MediaProjection to be initiated from a foreground service explicitly declared with `FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION`. This PR introduces the necessary service, manifest configurations, and updates the `UsbAudioManager` to comply with this requirement, ensuring proper system audio capture.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbece36d-288b-4cc0-8ff8-8e2f6ae534d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbece36d-288b-4cc0-8ff8-8e2f6ae534d9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

